### PR TITLE
Add util functions for getCompiler{Host|Port}

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,19 +36,21 @@ var parse = exports.parse = function(src, lexicon, resume) {
   return nodePool;
 }
 
-process.argv.forEach(function (val, index, array) {
-  if (index < 2) return
-  
-  fs = require('fs')
-  fs.readFile(val, 'utf8', function (err, data) {
-    if (err) {
-      console.log(err);
-      return;
-    }
-    console.log("parsing: " + data);
-    var t0 = new Date;
-    parse(data, {}, function (err, ast) {
-      console.log("ast=" + JSON.stringify(ast, null, 2));
+if (!module.parent) {
+  process.argv.forEach(function (val, index, array) {
+    if (index < 2) return
+    
+    fs = require('fs')
+    fs.readFile(val, 'utf8', function (err, data) {
+      if (err) {
+        console.log(err);
+        return;
+      }
+      console.log("parsing: " + data);
+      var t0 = new Date;
+      parse(data, {}, function (err, ast) {
+        console.log("ast=" + JSON.stringify(ast, null, 2));
+      });
     });
   });
-});
+}

--- a/package.json
+++ b/package.json
@@ -39,11 +39,16 @@
     "babel-preset-react": "^6.1.2",
     "babelify": "^7.0.2",
     "browserify": "^12.0.1",
+    "chai": "^4.2.0",
     "d3": "4.7.1",
     "flow-bin": "^0.32.0",
     "graceful-fs": "^4.1.15",
+    "mocha": "^6.1.3",
     "react": "0.14.5",
     "react-dom": "0.14.5",
     "uglify-js": "^2.7.3"
+  },
+  "scripts": {
+    "test": "mocha --reporter spec"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,22 @@
+
+function getCompilerHost(lang, config) {
+  if (config.hosts.get(lang)) {
+    return config.hosts.get(lang);
+  }
+  if (config.isLocalCompiler) {
+    return 'localhost';
+  }
+  return `${lang}.artcompiler.com`;
+}
+exports.getCompilerHost = getCompilerHost;
+
+function getCompilerPort(lang, config) {
+  if (config.ports.get(lang)) {
+    return config.ports.get(lang);
+  }
+  if (config.isLocalCompiler) {
+    return `5${lang.substring(1)}`;
+  }
+  return '80';
+}
+exports.getCompilerPort = getCompilerPort;

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,34 @@
+const {expect} = require('chai');
+
+const {getCompilerHost, getCompilerPort} = require('./../src/utils.js');
+
+describe('utils', () => {
+  describe('getCompilerHost', () => {
+    it('should return localhost if isLocalCompiler is true', () => {
+      const config = {isLocalCompiler: true, hosts: new Map()};
+      expect(getCompilerHost('L0', config)).to.equal('localhost');
+    });
+    it('should return default if isLocalCompiler is false', () => {
+      const config = {isLocalCompiler: false, hosts: new Map()};
+      expect(getCompilerHost('L0', config)).to.equal('L0.artcompiler.com');
+    });
+    it('should return override if hosts is set', () => {
+      const config = {isLocalCompiler: false, hosts: new Map([['L0', 'mycompiler.com']])};
+      expect(getCompilerHost('L0', config)).to.equal('mycompiler.com');
+    });
+  });
+  describe('getCompilerPort', () => {
+    it('should return localhost if isLocalCompiler is true', () => {
+      const config = {isLocalCompiler: true, ports: new Map()};
+      expect(getCompilerPort('L0', config)).to.equal('50');
+    });
+    it('should return default if isLocalCompiler is false', () => {
+      const config = {isLocalCompiler: false, ports: new Map()};
+      expect(getCompilerPort('L0', config)).to.equal('80');
+    });
+    it('should return override if ports is set', () => {
+      const config = {isLocalCompiler: false, ports: new Map([['L0', '42']])};
+      expect(getCompilerPort('L0', config)).to.equal('42');
+    });
+  });
+});


### PR DESCRIPTION
This is some of the ground work for allowing the host/gateway to configure where to send compiler requests.