### PR TITLE
Persistent id to object

### DIFF
--- a/app.js
+++ b/app.js
@@ -252,31 +252,39 @@ app.get('/lang', function(req, res) {
       } else {
         let queryString = "SELECT id FROM pieces WHERE language='" + lang + "' ORDER BY id DESC";
         dbQuery(queryString, (err, result) => {
-          let rows = result.rows;
-          if (rows.length === 0) {
-            var insertStr =
+          if (err) {
+            console.log(err);
+            res.sendStatus(500);
+            return;
+          }
+          if (result.rows.length > 0) {
+            res.redirect("/item?id=" + encodeID([langID, result.rows[0].id, 0]));
+          } else {
+            const insertStr =
               "INSERT INTO pieces (user_id, parent_id, views, forks, created, src, obj, language, label)" +
               " VALUES ('" + 0 + "', '" + 0 + "', '" + 0 +
               " ', '" + 0 + "', now(), '" + "| " + lang + "', '" + 'NULL' +
               " ', '" + lang + "', '" + "show" + "');"
-            dbQuery(insertStr, function(err, result) {
+            dbQuery(insertStr, (err, result) => {
               if (err) {
                 console.log("ERROR GET /pieces/:lang err=" + err);
                 res.sendStatus(400);
                 return;
               }
               dbQuery(queryString, (err, result) => {
-                let rows = result.rows;
-                if (rows.length > 0) {
-                  res.redirect("/form?id=" + rows[0].id);
+                if (err) {
+                  console.log(err);
+                  res.sendStatus(500);
+                  return;
+                }
+                if (result.rows.length > 0) {
+                  res.redirect("/form?id=" + result.rows[0].id);
                 } else {
                   console.log("[1] GET /lang ERROR 404 ");
                   res.sendStatus(404);
                 }
               });
             });
-          } else {
-            res.redirect("/item?id=" + encodeID([langID, rows[0].id, 0]));
           }
         });
       }

--- a/app.js
+++ b/app.js
@@ -650,11 +650,13 @@ function itemToID({userId, lang, ast}, resume) {
   }
 
   if (hash) {
-    const query = `SELECT id FROM pieces WHERE hash='${hash}' LIMIT 2`;
+    // FIXME How do we handle collisions? Are they so rare we don't need to
+    // worry about them?
+    const query = `SELECT id FROM pieces WHERE hash='${hash}' LIMIT 1`;
     dbQuery(query, (err, result) => {
       if (err) {
         resume(err);
-      } else if (result.rows.length > 0) {
+      } else if (result.rows.length === 1) {
         const itemID = result.rows[0].id;
         resume(null, itemID);
       } else {

--- a/app.js
+++ b/app.js
@@ -652,7 +652,7 @@ function itemToID({userId, lang, ast}, resume) {
   if (hash) {
     // FIXME How do we handle collisions? Are they so rare we don't need to
     // worry about them?
-    const query = `SELECT id FROM pieces WHERE hash='${hash}' LIMIT 1`;
+    const query = `SELECT id FROM pieces WHERE hash='${hash}' ORDER BY created LIMIT 1`;
     dbQuery(query, (err, result) => {
       if (err) {
         resume(err);

--- a/app.js
+++ b/app.js
@@ -1107,13 +1107,17 @@ app.put('/compile', function (req, res) {
             console.log(`ERROR PUT /compile parse err=${err.message}`);
             res.sendStatus(400);
           } else {
-            compile(ast);
+            compile({ res, ast });
           }
         });
       } else {
-        compile(ast);
+        compile({ res, ast });
       }
-      function compile(ast) {
+      function compile({ res, ast }) {
+        // TODO Try to lookup the item
+        compileInternal({ res, ast, itemID: null });
+      }
+      function compileInternal({ res, ast, itemID }) {
         if (itemID) {
           let langID = lang.charAt(0) === 'L' ? +lang.substring(1) : +lang;
           let codeID = row.id;

--- a/app.js
+++ b/app.js
@@ -129,9 +129,10 @@ function dbQuery(query, resume) {
       console.log(`Query took ${duration.toFixed(3)}ms - ${query}`);
     }
     if (err) {
-      return console.error('Error executing query', err.stack)
+      resume(err);
+    } else {
+      resume(null, result);
     }
-    resume(null, result);
   });
 };
 

--- a/app.js
+++ b/app.js
@@ -117,7 +117,7 @@ function insertItem(userID, itemID, resume) {
 }
 
 function dbQuery(query, resume) {
-  if ('string' !== typeof query) {
+  if (!isNonEmptyString(query)) {
     resume(null, {});
     return;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+const crypto = require('crypto');
 
 function getCompilerHost(lang, config) {
   if (config.hosts.get(lang)) {
@@ -25,3 +27,14 @@ function isNonEmptyString(str) {
   return ('string' === typeof(str) && 0 < str.length);
 }
 exports.isNonEmptyString = isNonEmptyString;
+
+function itemToHash({userId, lang, ast}) {
+  userId = Number.parseInt(userId);
+  assert(!Number.isNaN(userId), 'userId must be a integer');
+  assert(/^L\d+/.test(lang), 'lang must be a string with format L#');
+  assert('object' === typeof ast && null !== ast, 'ast must be a non null object');
+  const hasher = crypto.createHash('sha256');
+  hasher.update(`${userId}.${lang}.${JSON.stringify(ast)}`);
+  return hasher.digest('hex');
+}
+exports.itemToHash = itemToHash;

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,10 +23,10 @@ function getCompilerPort(lang, config) {
 }
 exports.getCompilerPort = getCompilerPort;
 
-function isNonEmptyString(str) {
-  return ('string' === typeof(str) && 0 < str.length);
+function isNotEmptyStringOrNull(str) {
+  return (str !== null || typeof str === 'string' && str.length > 0 && str !== "null");
 }
-exports.isNonEmptyString = isNonEmptyString;
+exports.isNotEmptyStringOrNull = isNotEmptyStringOrNull;
 
 function itemToHash({userId, lang, ast}) {
   userId = Number.parseInt(userId);

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,10 +23,10 @@ function getCompilerPort(lang, config) {
 }
 exports.getCompilerPort = getCompilerPort;
 
-function isNotEmptyStringOrNull(str) {
-  return (str !== null || typeof str === 'string' && str.length > 0 && str !== "null");
+function isNonEmptyString(str) {
+  return typeof str === 'string' && str.length > 0;
 }
-exports.isNotEmptyStringOrNull = isNotEmptyStringOrNull;
+exports.isNonEmptyString = isNonEmptyString;
 
 function itemToHash({userId, lang, ast}) {
   userId = Number.parseInt(userId);

--- a/util/initgcdb.sql
+++ b/util/initgcdb.sql
@@ -104,7 +104,8 @@ CREATE TABLE pieces (
     img text,
     address character(42),
     label character varying(30),
-    ast json
+    ast json,
+    hash text
 );
 
 

--- a/util/pg-add-column-hash.sql
+++ b/util/pg-add-column-hash.sql
@@ -1,0 +1,11 @@
+BEGIN;
+LOCK pieces;
+
+ALTER TABLE pieces ADD COLUMN IF NOT EXISTS hash TEXT;
+
+UPDATE
+  pieces
+SET
+  hash=encode(digest(user_id::text || '.' || language::text || '.' || ast::text, 'sha256'), 'hex');
+
+COMMIT;


### PR DESCRIPTION
This PR adds an item to hash mapping for faster item look ups

This PR should not be deployed until the databases are update with the `pg-add-column-hash.sql` script is run.